### PR TITLE
Implemented alias for the smart pointer and vector declarations

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -73,7 +73,7 @@ void Game::PlaceFood() {
 void Game::Update() {
   if (!snake.alive) return;
 
-  pv_SDL borderLine { new vectorPoints{border.borderLine} };
+  pv_SDL borderLine = std::make_unique<vectorPoints>(border.borderLine);
 
   snake.Update(std::move(borderLine));
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -73,7 +73,7 @@ void Game::PlaceFood() {
 void Game::Update() {
   if (!snake.alive) return;
 
-  std::unique_ptr<std::vector<SDL_Point>> borderLine = std::make_unique<std::vector<SDL_Point>>(border.borderLine);
+  pv_SDL borderLine { new vectorPoints{border.borderLine} };
 
   snake.Update(std::move(borderLine));
 

--- a/src/game.h
+++ b/src/game.h
@@ -8,6 +8,9 @@
 #include "snake.h"
 #include "border.h"
 
+using vectorPoints = std::vector<SDL_Point>;
+using pv_SDL = std::unique_ptr<vectorPoints>;
+
 class Game {
  public:
   Game();
@@ -30,7 +33,7 @@ class Game {
   std::uniform_int_distribution<int> random_h;
 
   int score{0};
-  std::unique_ptr<std::vector<SDL_Point>> borderLine;
+  pv_SDL borderLine;
 
   void PlaceFood();
   void Update();

--- a/src/snake.cpp
+++ b/src/snake.cpp
@@ -13,7 +13,7 @@ Snake::Snake(int grid_width, int grid_height)
 
 Snake::~Snake() {}
 
-void Snake::Update(std::unique_ptr<std::vector<SDL_Point>> borderLine) {
+void Snake::Update(pv_SDL borderLine) {
   SDL_Point prev_cell{
       static_cast<int>(head_x),
       static_cast<int>(head_y)
@@ -55,7 +55,7 @@ void Snake::UpdateHead() {
   head_y = fmod(head_y + grid_height, grid_height);
 }
 
-void Snake::UpdateBody(SDL_Point &current_head_cell, SDL_Point &prev_head_cell, std::unique_ptr<std::vector<SDL_Point>> borderLine) {
+void Snake::UpdateBody(SDL_Point &current_head_cell, SDL_Point &prev_head_cell, pv_SDL borderLine) {
   // Add previous head location to vector
   body.push_back(prev_head_cell);
 

--- a/src/snake.h
+++ b/src/snake.h
@@ -6,6 +6,9 @@
 #include "SDL.h"
 #include "border.h"
 
+using vectorPoints = std::vector<SDL_Point>;
+using pv_SDL = std::unique_ptr<vectorPoints>;
+
 class Snake {
  public:
   Snake();
@@ -16,7 +19,7 @@ class Snake {
 
   enum class Direction { kUp, kDown, kLeft, kRight };
 
-  void Update(std::unique_ptr<std::vector<SDL_Point>> borderLine);
+  void Update(pv_SDL borderLine);
   void GrowBody();
   bool SnakeCell(int x, int y);
 
@@ -27,11 +30,11 @@ class Snake {
   bool alive{true};
   float head_x;
   float head_y;
-  std::vector<SDL_Point> body;
+  vectorPoints body;
 
  private:
   void UpdateHead();
-  void UpdateBody(SDL_Point &current_cell, SDL_Point &prev_cell, std::unique_ptr<std::vector<SDL_Point>> borderLine);
+  void UpdateBody(SDL_Point &current_cell, SDL_Point &prev_cell, pv_SDL borderLine);
 
   bool growing{false};
   int grid_width;


### PR DESCRIPTION
	For easier reading, std::vector<SDL_Point> and std::unique_ptr<...> were alias'ed
	Compiles and runs correctly.